### PR TITLE
Fix: Famous API to fixes #8

### DIFF
--- a/app/schemas/post.py
+++ b/app/schemas/post.py
@@ -39,7 +39,8 @@ class FamousResponse(BaseModel):
     post_id: int
     user_id: str
     user_name: str
-    image_urls: List[HttpUrl]
+    profile_image_url: str # 포스팅에 등록된 이미지가 아니라 유저의 프로필 이미지이므로
+    like_count: int
     liked_by: List[Like]
 
 class PostCreate(BaseModel):


### PR DESCRIPTION
1. 닉네임
    - 문제상황: 기존 user_name에는 피드홈에 등록한 닉네임이 아니라 카카오톡에 등록되어 있는 사람 이름이 사용되었다
    - user_name에 프로필 닉네임이 표시되도록 수정

2. image_urls 수정
    - 문제상황: 기존 image_urls는 포스팅에 등록된 이미지, 그러나 해당 API에서 필요한 것은 포스팅을 등록한 사람의 프로필 이미지
    - 파라미터 이름 변경: image_urls -> profile_image_url
    - 데이터 타입 변경: List[Httpurl] -> str (프로필 이미지 1개이므로)
    - 해당 피드에 달린 좋아요 개수를 담은 like_count(int형) 파라미터도 추가